### PR TITLE
tests: use ginkgo from CLI, add FlakeAttempts and reset on each upgrade tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -289,8 +289,10 @@ jobs:
 
       - name: Run tests 🔧
         run: |
+          export GOPATH="/Users/runner/go"
           go get -u github.com/onsi/ginkgo/ginkgo
           go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
           make test
 
   publish:

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ QEMU_ARGS?=-bios /usr/share/qemu/ovmf-x86_64.bin
 QEMU_MEMORY?=2048
 PACKER_ARGS?=
 PUBLISH_ARGS?=
+GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
 ISO?=$(ROOT_DIR)/$(shell ls *.iso)
 
 export REPO_CACHE
@@ -150,4 +151,4 @@ test-clean:
 	vagrant box remove cos || true
 
 test: test-clean Vagrantfile prepare-test
-	cd $(ROOT_DIR)/tests && go test -timeout 3h
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./

--- a/tests/upgrade_test.go
+++ b/tests/upgrade_test.go
@@ -10,6 +10,7 @@ var _ = Describe("cOS Upgrade tests", func() {
 	BeforeEach(func() {
 		s = NewSUT("", "", "")
 		s.EventuallyConnects()
+		s.Reset()
 	})
 
 	Context("After install", func() {
@@ -25,7 +26,6 @@ var _ = Describe("cOS Upgrade tests", func() {
 				out, err := s.Command("sed -i 's|raccos/releases-.*|raccos/releases-amd64\"|g' /etc/luet/luet.yaml && cos-upgrade")
 				Expect(out).Should(ContainSubstring("does not have trust data"))
 				Expect(err).To(HaveOccurred())
-				s.Reset()
 			})
 
 			It("upgrades if verify is disabled on an unsigned upgrade channel", func() {
@@ -81,8 +81,7 @@ var _ = Describe("cOS Upgrade tests", func() {
 				Expect(out).Should(ContainSubstring("Booting from: active.img"))
 
 				s.Reboot()
-
-				s.Reset()
+				Expect(s.BootFrom()).To(Equal(Active))
 			})
 
 			It("upgrades to a specific image and reset back to the installed version", func() {
@@ -105,8 +104,6 @@ var _ = Describe("cOS Upgrade tests", func() {
 				Expect(out).ToNot(Equal(""))
 				//	Expect(out).ToNot(Equal(version))
 				Expect(out).To(Equal("0.4.32\n"))
-
-				s.Reset()
 			})
 		})
 	})


### PR DESCRIPTION
This should stabilize single tests by starting and finishing with a clean state each `It` block using`Reset()` before each one of them.

It also runs the suite tests with `ginkgo` instead of `go test`, so we can pass by few arguments overall that will help out:

- we make now the tests fail fast
- if there are failures, they are attempted 3 times
- more verbosity and progress printed to the terminal